### PR TITLE
Fix scoring section to match binary classification objective

### DIFF
--- a/2026/index.md
+++ b/2026/index.md
@@ -205,7 +205,7 @@ Please note that you remain the [owners](#ip) of any code that you submit, and w
 
 ## <a name="scoring"></a> Scoring
 
-Each team must develop and implement an algorithm that, given a PSG and basic demographic data, predicts the time to a cognitive impairment diagnosis, or if the patient will not be diagnosed with cognitive impairment.
+Each team must develop and implement an algorithm that, given a PSG and basic demographic data, predicts whether the patient will be diagnosed with cognitive impairment diagnosis in the future.
 
 To that end, we define three groups of patients:
 


### PR DESCRIPTION
## Summary
- Fixed inconsistent wording in the Scoring section of the 2026 competition page
- The Scoring section incorrectly described the task as predicting "time to a cognitive impairment diagnosis"
- Matches algorithms section: "predicts whether patient will be diagnosed with cognitive impairment diagnosis in future"

## Test plan
- Verify the Scoring section wording matches the Algorithms section
- Confirm the page renders correctly